### PR TITLE
Make world regex more permissive to allow any world prefix

### DIFF
--- a/src/main/java/cf/avicia/avomod2/client/eventhandlers/chatevents/MakeShoutsClickable.java
+++ b/src/main/java/cf/avicia/avomod2/client/eventhandlers/chatevents/MakeShoutsClickable.java
@@ -4,7 +4,6 @@ import cf.avicia.avomod2.utils.Utils;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
-import net.minecraft.util.ActionResult;
 
 import java.util.regex.Pattern;
 
@@ -30,7 +29,7 @@ public class MakeShoutsClickable {
     }
 
     private static boolean isMessageShout(Text message) {
-        Pattern pattern = Pattern.compile("^(.* \\[(?:NA|EU|AS)\\d*] shouts:) .*", Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile("^(.* \\[[A-Z]{2}\\d*] shouts:) .*", Pattern.CASE_INSENSITIVE);
         String messageString =  Utils.getUnformattedString(Utils.textWithoutTimeStamp(message).getString());
         return pattern.matcher(messageString).find();
     }

--- a/src/main/java/cf/avicia/avomod2/client/eventhandlers/hudevents/BombBellTracker.java
+++ b/src/main/java/cf/avicia/avomod2/client/eventhandlers/hudevents/BombBellTracker.java
@@ -74,7 +74,7 @@ public class BombBellTracker {
         String unformattedMessage = Utils.getUnformattedString(Utils.textWithoutTimeStamp(message).getString());
         if (unformattedMessage == null || !unformattedMessage.startsWith("[Bomb Bell]")) return message;
 
-        ArrayList<String> matches = Utils.getMatches(unformattedMessage, "(?<= thrown a )[a-zA-Z ]+(?= Bomb on)|(?<= on )(?:NA|EU)\\d{1,4}");
+        ArrayList<String> matches = Utils.getMatches(unformattedMessage, "(?<= thrown a )[a-zA-Z ]+(?= Bomb on)|(?<= on )[A-Z]{2}\\d{1,4}");
         if (matches.size() != 2) return message;
 
         String bombName = matches.get(0);


### PR DESCRIPTION
This makes bombs thrown on asia server be recognised and also prevents this from breaking for any further regions that might be added down the line