### PR TITLE
Fixed lastseen command

### DIFF
--- a/src/main/java/cf/avicia/avomod2/client/commands/subcommands/LastSeenCommand.java
+++ b/src/main/java/cf/avicia/avomod2/client/commands/subcommands/LastSeenCommand.java
@@ -18,9 +18,10 @@ public class LastSeenCommand {
                             Thread thread = new Thread(() -> {
                                 PlayerStats playerStats = new PlayerStats(username);
                                 String formattedUsername = playerStats.getUsername();
+                                boolean isOnline = playerStats.isOnline();
                                 String world = playerStats.getServer();
                                 String timeSinceLastJoin = playerStats.getTimeSinceLastJoin();
-                                if (formattedUsername != null && world != null) {
+                                if (formattedUsername != null && world != null && isOnline) {
                                     context.getSource().sendFeedback(Text.literal("§b" + formattedUsername + "§7 is online on §b" + world));
                                 } else if(timeSinceLastJoin != null) {
                                     context.getSource().sendFeedback(Text.literal("§b" + formattedUsername + "§7 was last seen §b" + timeSinceLastJoin + "§7 ago."));

--- a/src/main/java/cf/avicia/avomod2/webrequests/wynnapi/PlayerStats.java
+++ b/src/main/java/cf/avicia/avomod2/webrequests/wynnapi/PlayerStats.java
@@ -40,6 +40,17 @@ public class PlayerStats {
         }
     }
 
+    public boolean isOnline() {
+        try {
+            return Objects.requireNonNull(getPlayerData())
+                    .get("online")
+                    .getAsBoolean();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
     public String getServer() {
         try {
             return Objects.requireNonNull(getPlayerData())


### PR DESCRIPTION
The server field never gets nulled, so it always has the player's last active world. Now the command checks the online field to see if someone's online instead of the server field.

<img width="491" height="60" alt="image" src="https://github.com/user-attachments/assets/85ad5bc5-7f17-41b3-8f43-17049c640c37" />
